### PR TITLE
refactor: command parameter등 체크시 CommandSpec 클래스 활용하도록 refactor

### DIFF
--- a/command.py
+++ b/command.py
@@ -1,0 +1,21 @@
+from enum import StrEnum
+
+class Command(StrEnum):
+    READ  = "R"
+    WRITE = "W"
+    ERASE = "E"
+
+class CommandSpec:
+    NUM_PARAMS: dict[Command, int] = {Command.READ: 2, Command.WRITE: 3, Command.ERASE: 3}
+    VALID_COMMANDS: list[Command] = [Command.READ, Command.WRITE, Command.ERASE]
+    def get_num_params(self, command) -> int:
+        return self.NUM_PARAMS.get(command, -1)
+
+    def is_valid_command(self, command):
+        if command in self.VALID_COMMANDS:
+            return True
+        return False
+
+    @property
+    def minimum_num_params(self):
+        return min(self.NUM_PARAMS.values())

--- a/lba_validator.py
+++ b/lba_validator.py
@@ -1,22 +1,19 @@
+from command import CommandSpec, Command
 from parameter_validator_interface import ParameterValidatorInterface
 
 
 class LBAValidator(ParameterValidatorInterface):
-    MIN_NUM_RUN_PARAMETERS = 2
-    NUM_WRITE_PARAMETERS = 3
-    NUM_READ_PARAMETERS = 2
-    AVAILABLE_COMMANDS = ['R', 'W']
     VALUE_LENGTH = 10
 
-    def __init__(self, lba_length):
-        super().__init__()
+    def __init__(self, spec:CommandSpec, lba_length:int):
+        super().__init__(spec)
         self.lba_length = lba_length
 
     def is_valid(self, params):
         if not isinstance(params, (list, tuple)):
             return False
 
-        if len(params) < self.MIN_NUM_RUN_PARAMETERS:
+        if len(params) < self._spec.minimum_num_params:
             return False
 
         command, address = params[0], params[1]
@@ -24,15 +21,16 @@ class LBAValidator(ParameterValidatorInterface):
             return False
 
         address = int(address)
-        if command not in self.AVAILABLE_COMMANDS:
+        if not self._spec.is_valid_command(command):
             return False
+
+        if len(params) != self._spec.get_num_params(command):
+            return False
+
         if address >= self.lba_length or address < 0:
             return False
-        if command == 'R' and len(params) != self.NUM_READ_PARAMETERS:
-            return False
+
         if command == 'W':
-            if len(params) != self.NUM_WRITE_PARAMETERS:
-                return False
             value = params[2]
             if len(value) != self.VALUE_LENGTH:
                 return False

--- a/parameter_validator_interface.py
+++ b/parameter_validator_interface.py
@@ -1,7 +1,11 @@
 from abc import ABC, abstractmethod
+from command import CommandSpec
 
 
 class ParameterValidatorInterface(ABC):
+    def __init__(self, spec: CommandSpec):
+        self._spec = spec
+
     @abstractmethod
     def is_valid(self, params):
         pass

--- a/ssd.py
+++ b/ssd.py
@@ -1,3 +1,6 @@
+import dataclasses
+
+from command import Command, CommandSpec
 from file_output import FileOutput
 from lba_validator import LBAValidator
 from nand import Nand
@@ -6,14 +9,13 @@ import sys
 class SSD:
     LBA_LENGTH = 100
     ERROR_MSG = "ERROR"
-    READ_COMMAND = "R"
-    WRITE_COMMAND = "W"
     OUTPUT_FILE = "ssd_output.txt"
+
     def __init__(self, device):
         self._device = device
         self._out_writer = FileOutput(self.OUTPUT_FILE)
         self._last_result = None
-        self._param_validator = LBAValidator(self.LBA_LENGTH)
+        self._param_validator = LBAValidator(CommandSpec(), self.LBA_LENGTH)
 
     @property
     def result(self):
@@ -33,12 +35,15 @@ class SSD:
 
         command, address = params[0], int(params[1])
         try:
-            if command == self.READ_COMMAND:
+            if command == Command.READ:
                 self.result = self._device.read(address)
-            if command == self.WRITE_COMMAND:
+            if command == Command.WRITE:
                 value = params[2]
                 self._device.write(address, value)
                 self.result = ""
+            if command == Command.ERASE:
+                count = params[2]
+                self.result = self._device.erase()
         except Exception as e:
             self.result = self.ERROR_MSG
             return False


### PR DESCRIPTION
기존에 Constant로 parameter 정보 입력하던 것들이 SSD 및 Validator 구현을 지저분하게 하는 것 같아,
Command (enum class) 와 CommandSpec 클래스로 뺐습니다.
Test Case는 모두 통과 하였습니다.

============================= test session starts =============================
collecting ... collected 22 items

test_ssd.py::TestSsdWithMock::test_read_command 
test_ssd.py::TestSsdWithMock::test_write_command 
test_ssd.py::TestSsdWithMock::test_uninitialized_data 
test_ssd.py::TestSsdWithMock::test_write_data 
test_ssd.py::TestSsdWithMock::test_read_minus_address 
test_ssd.py::TestSsdWithMock::test_write_minus_address 
test_ssd.py::TestSsdWithMock::test_read_out_of_bounds 
test_ssd.py::TestSsdWithMock::test_write_out_of_bounds 
test_ssd.py::TestSsdWithMock::test_invalid_command 
test_ssd.py::TestSsdWithMock::test_invalid_read_address 
test_ssd.py::TestSsdWithMock::test_invalid_write_address 
test_ssd.py::TestSsdWithMock::test_invalid_write_data 
test_ssd.py::TestSsd::test_file_creation PASSED                   [  4%]PASSED                  [  9%]PASSED             [ 13%]PASSED                     [ 18%]PASSED             [ 22%]PASSED            [ 27%]PASSED             [ 31%]PASSED            [ 36%]PASSED                [ 40%]PASSED           [ 45%]PASSED          [ 50%]PASSED             [ 54%]
test_ssd.py::TestSsd::test_initial_nand_file 
test_ssd.py::TestSsd::test_initial_output_file 
test_ssd.py::TestSsd::test_read_empty_data 
test_ssd.py::TestSsd::test_write_data 
test_ssd.py::TestSsd::test_repeat_write_to_same_address 
test_ssd.py::TestSsd::test_write_multiple_address 
test_ssd.py::TestSsd::test_write_success 
test_ssd.py::TestSsd::test_out_of_lba_range_read 
test_ssd.py::TestSsd::test_out_of_lba_range_write 

======================== 21 passed, 1 skipped in 0.08s ========================