### PR TITLE
refactor: logger를 명목상 singleton이 아닌 실제 Singleton으로 동작하게 함.

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -2,7 +2,15 @@ import datetime
 import inspect
 import os
 
+def singleton(cls):
+    instances = {}
+    def wrapper(*args, **kwargs):
+        if cls not in instances:
+            instances[cls] = cls(*args, **kwargs)
+        return instances[cls]
+    return wrapper
 
+@singleton
 class Logger:
     def __init__(self, is_stdout: bool, file_path: str, max_bytes: int, test_mode=False):
         self.is_stdout = is_stdout

--- a/test_logger.py
+++ b/test_logger.py
@@ -39,6 +39,21 @@ def write_generate_1_file(logger:Logger, target_bytes: int):
         message = f"Test message {count} to fill up the log file"
         logger.print_log(message)
 
+def test_singleton_without_changing_value():
+    logger = Logger(is_stdout=True, file_path=TEST_LATEST_FILE, max_bytes=TEST_MAX_BYTES,test_mode=True)
+    another_logger = Logger(is_stdout=False, file_path=TEST_LATEST_FILE, max_bytes=TEST_MAX_BYTES,test_mode=True)
+    assert logger is another_logger
+    assert logger.is_stdout == True
+
+def test_singleton_update_settings():
+    logger = Logger(is_stdout=True, file_path=TEST_LATEST_FILE, max_bytes=TEST_MAX_BYTES, test_mode=True)
+    another_logger = Logger(is_stdout=True, file_path=TEST_LATEST_FILE, max_bytes=TEST_MAX_BYTES, test_mode=True)
+    assert logger is another_logger
+    another_logger.update_settings(is_stdout=False, file_path=TEST_LATEST_FILE, max_bytes=100)
+
+    assert logger.is_stdout == False
+    assert logger.max_bytes == 100
+    assert logger.file_path == TEST_LATEST_FILE
 
 def test_print_log_success(stdout_logger):
     # stdout 출력 캡처


### PR DESCRIPTION
- 기존 동작은 실제로 Instance를 여러번 New로 생성하면 여러개가 생기는 구조였음
- 즉, 사용자가 Singleton 처럼 사용하도록 유의해야했음
- Singleton annotation (`@singleton`)을 아래와 같이 추가함으로써 실제로 여러번 instance를 생성해도 기존의 instance를 사용하도록 수정함. + 테스트 추가